### PR TITLE
feat: add Zig 0.15.X support

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .fingerprint = 0xadae4aecca466a13,
     .name = .wasmer_zig_api,
     .version = "0.3.0",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -4,6 +4,8 @@ const meta = std.meta;
 const trait = std.meta.trait;
 const log = std.log.scoped(.wasm_zig);
 
+const c_callconv: std.builtin.CallingConvention = .c;
+
 var CALLBACK: usize = undefined;
 
 // @TODO: Split these up into own error sets
@@ -98,7 +100,7 @@ pub const Module = opaque {
     extern "c" fn wasm_module_exports(?*const Module, *ExportTypeVec) void;
 };
 
-fn cb(params: ?*const Valtype, results: ?*Valtype) callconv(.C) ?*Trap {
+fn cb(params: ?*const Valtype, results: ?*Valtype) callconv(c_callconv) ?*Trap {
     _ = params;
     _ = results;
     const func = @as(*const fn () void, @ptrFromInt(CALLBACK));
@@ -660,7 +662,7 @@ pub const ExportTypeVec = extern struct {
     extern "c" fn wasm_exporttype_vec_delete(*ExportTypeVec) void;
 };
 
-pub const Callback = fn (?*const Valtype, ?*Valtype) callconv(.C) ?*Trap;
+pub const Callback = fn (?*const Valtype, ?*Valtype) callconv(c_callconv) ?*Trap;
 
 pub const ByteVec = extern struct {
     size: usize,

--- a/src/wasmer.zig
+++ b/src/wasmer.zig
@@ -2,7 +2,14 @@ const std = @import("std");
 const builtin = @import("builtin");
 pub const wasm = @import("./wasm.zig");
 
-pub usingnamespace @import("./wasi.zig");
+pub const wasi = @import("./wasi.zig");
+pub const WasiError = wasi.WasiError;
+pub const WasiConfig = wasi.WasiConfig;
+pub const WasiEnv = wasi.WasiEnv;
+pub const WasiVersion = wasi.WasiVersion;
+pub const getWasiVersion = wasi.getWasiVersion;
+pub const getImports = wasi.getImports;
+pub const getStartFunction = wasi.getStartFunction;
 
 // Re-exports
 pub const ExternVec = wasm.ExternVec;


### PR DESCRIPTION
- Replace `pub usingnamespace` with explicit reexports
- Lowercase `.c` calling convention
- New module API for build.zig 